### PR TITLE
bugfix release

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open("README.md", 'r', encoding='utf-8"') as fh:
 setup(
     name='TDXLib',
     description='a python library for interacting with the TeamDynamix Web API',
-    version='0.3.0',
+    version='0.3.3',
     author='Nat Biggs, Stephen Gaines, Josiah Lansford',
     author_email='tdxlib@cedarville.edu',
     packages=['tdxlib'],

--- a/tdxlib/__init__.py
+++ b/tdxlib/__init__.py
@@ -7,4 +7,4 @@ import tdxlib.tdx_ticket_integration
 import tdxlib.tdx_ticket
 import tdxlib.tdx_utils
 
-__version__ = "0.3.0"
+__version__ = "0.3.3"

--- a/testing/tdx_asset_testing.py
+++ b/testing/tdx_asset_testing.py
@@ -393,6 +393,18 @@ class TdxAssetTesting(unittest.TestCase):
         self.assertTrue(validate2['Attributes'][0]['Name'] == self.testing_vars['attributes1'][0]['Name'])
         self.assertTrue(validate1['StatusName'] == self.testing_vars['asset_status2']['Name'])
 
+    def test_move_child_assets(self):
+        if not self.timestamp:
+            self.setUp()
+        child_asset_id = self.testing_vars['child_asset']['ID']
+        parent_asset_id = self.testing_vars['parent_asset']['ID']
+        other_asset_id = self.testing_vars['asset1']['ID']
+        self.tax.move_child_assets(parent_asset_id, other_asset_id)
+        validate = self.tax.get_asset_by_id(child_asset_id)
+        self.assertTrue(str(validate['ParentID']) == str(other_asset_id))
+        self.tax.move_child_assets(other_asset_id, parent_asset_id)
+        validate2 = self.tax.get_asset_by_id(child_asset_id)
+        self.assertTrue(str(validate2['ParentID']) == str(parent_asset_id))
 
 if __name__ == "__main__":
     suite = unittest.TestLoader().loadTestsFromTestCase(TdxAssetTesting)


### PR DESCRIPTION
-bumps version for bugfix release
-fixes import problems in asset integration
-renames an argument of get_asset_custom_attribute_by_name_id() to not overlap with python defaults
-fixes move_child_assets() to be compatible with asset IDs, not just dicts
-fixes copy_asset_attributes to correctly exempt the asset's CAs.