### PR TITLE
 Fix bug in building full host URL

### DIFF
--- a/.github/workflows/pythonpublish.yml
+++ b/.github/workflows/pythonpublish.yml
@@ -17,6 +17,9 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install setuptools wheel twine
+    - name: Run Unit Tests
+      run: |
+        python -m unittest
     - name: Build and publish
       env:
         TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}

--- a/tdxlib/tdx_integration.py
+++ b/tdxlib/tdx_integration.py
@@ -178,7 +178,7 @@ class TDXIntegration:
         if fullhost is None:
             self.api_url = 'https://' + self.org_name + '.teamdynamix.com' + api_end
         else:
-            self.api_url = 'https://' + fullhost + '/' + api_end
+            self.api_url = 'https://' + fullhost + api_end
         if self.password == 'Prompt':
             pass_prompt = 'Enter the TDX Password for user ' + self.username + '(this password will not be stored): '
             self.password = getpass.getpass(pass_prompt)

--- a/test/test_tdx_ticket_integration.py
+++ b/test/test_tdx_ticket_integration.py
@@ -1,0 +1,45 @@
+import unittest
+from tdxlib import tdx_integration
+from unittest.mock import patch
+
+
+class MockConfigParser(dict):
+
+    def getboolean(self, key):
+        return bool(self[key])
+
+    def read(self, filename):
+        pass
+
+
+class TdxMockTesting(unittest.TestCase):
+
+    def setUp(self):
+        config = MockConfigParser({
+            'TDX API Settings': MockConfigParser({
+                'fullhost': 'tdx.myuniversity.org',
+                'sandbox': True,
+                'username': '',
+                'password': 'not-a-real-password',
+                'ticketAppId': '',
+                'assetAppId': '',
+                'caching': False,
+                'timezone': '-0500',
+                'logLevel': 'ERROR',
+            })
+        })
+        patcher = patch("configparser.ConfigParser", return_value=config)
+        self.mock_config = patcher.start()
+        self.addCleanup(patcher.stop)
+
+    @patch.object(tdx_integration.TDXIntegration, "auth")
+    def test_api_url(self, config_parser):
+        """Check for extra slashes in API URL"""
+        tdx = tdx_integration.TDXIntegration('../tdxlib.ini')
+        self.assertNotIn('//', tdx.api_url.lstrip('https://'),
+                         f'Extra slash in URL { tdx.api_url }')
+
+
+if __name__ == "__main__":
+    suite = unittest.TestLoader().loadTestsFromTestCase(TdxMockTesting)
+    unittest.TextTestRunner(verbosity=2).run(suite)


### PR DESCRIPTION
- Fix name resolution error when using full host URL. The error was caused by an extra slash in the URL path.
- Add new unit test to GitHub Actions workflow
- Add `test` directory to allow `python -m unittest`
