### PR TITLE
Remove stray import lines in tdx_ticket_integration.py

### DIFF
--- a/.github/workflows/pythonpublish.yml
+++ b/.github/workflows/pythonpublish.yml
@@ -17,6 +17,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install setuptools wheel twine
+        pip install -r requirements.txt
     - name: Run Unit Tests
       run: |
         python -m unittest

--- a/tdxlib/tdx_ticket_integration.py
+++ b/tdxlib/tdx_ticket_integration.py
@@ -1,9 +1,7 @@
-import tdx_api_exceptions
-import tdx_ticket
-import tdxlib.tdx_ticket
 import datetime
-import tdxlib.tdx_integration
 import tdxlib.tdx_api_exceptions
+import tdxlib.tdx_integration
+import tdxlib.tdx_ticket as tdx_ticket
 from typing import Union
 from typing import BinaryIO
 


### PR DESCRIPTION
We were have been getting `ModuleNotFoundError`s during testing. It appears that a couple of import lines may have been leftover during refactoring.

```bash
$ ~/projects/secops-soar-tdx$ pytest -k test_connectivity
ImportError while loading conftest '/home/tzturner/projects/secops-soar-tdx/tests/conftest.py'.
tests/conftest.py:9: in <module>
    from phTDX.tdx_connector import TdxConnector
src/phTDX/tdx_connector.py:21: in <module>
    import tdxlib
venv/lib/python3.9/site-packages/tdxlib/__init__.py:6: in <module>
    import tdxlib.tdx_ticket_integration
venv/lib/python3.9/site-packages/tdxlib/tdx_ticket_integration.py:1: in <module>
    import tdx_api_exceptions
E   ModuleNotFoundError: No module named 'tdx_api_exceptions'
```