### PR TITLE
Fix reassigning to group

### DIFF
--- a/tdxlib/tdx_ticket_integration.py
+++ b/tdxlib/tdx_ticket_integration.py
@@ -315,7 +315,7 @@ class TDXTicketIntegration(tdxlib.tdx_integration.TDXIntegration):
     
         """
         if group:
-            reassign = {'ResponsibleUid': self.get_group_by_name(responsible)['ID']}
+            reassign = {'ResponsibleGroupID': self.get_group_by_name(responsible)['ID']}
         else:
             reassign = {'ResponsibleUid': self.get_person_by_name_email(responsible)['UID']}
         return self.edit_ticket(ticket_id, reassign)

--- a/tdxlib/tdx_ticket_integration.py
+++ b/tdxlib/tdx_ticket_integration.py
@@ -315,7 +315,7 @@ class TDXTicketIntegration(tdxlib.tdx_integration.TDXIntegration):
     
         """
         if group:
-            reassign = {'GroupID': self.get_group_by_name(responsible)['ID']}
+            reassign = {'ResponsibleUid': self.get_group_by_name(responsible)['ID']}
         else:
             reassign = {'ResponsibleUid': self.get_person_by_name_email(responsible)['UID']}
         return self.edit_ticket(ticket_id, reassign)


### PR DESCRIPTION
+ Use 'ResponsibleGroupID' instead of 'GroupID' when reassigning a ticket to a group
  + 'GroupID' appears to be a non-editable field.